### PR TITLE
Adding Error Message Rather Than Backtrace Upon Python 3 Import

### DIFF
--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -1,3 +1,7 @@
+import sys
+if sys.version_info >= (3, 0):
+    sys.stderr.write("metric-learn works with python 2.6+, but not python 3.*. Exiting.")
+    sys.exit(1)
 from itml import ITML
 from lmnn import LMNN
 from lsml import LSML


### PR DESCRIPTION
Modified metric_learn/\__init\__.py to fail with more informative error when importing metric_learn is attempted with python 3.*

Finding out that I should be using python2 rather than python3 with metric-learn took me about 2 minutes, and with this update somebody in that position could be immediately told that that's the issue.

When running `import metric_learn` with anaconda python 3.4.3, the error message I added does in fact get printed on stderr and the program exits. When running `import metric_learn` with anaconda python 2.7.10, the error condition is not satisfied and the import succeeds.