### PR TITLE
Added get_params, set_params and params moved to dictionary

### DIFF
--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -70,4 +70,4 @@ class BaseMetricLearner(object):
     -------
     self
     """
-    self.params = {**self.params, **kwarg}
+    self.params.update(kwarg)

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -47,7 +47,7 @@ class BaseMetricLearner(object):
     return X.dot(L.T)
 
   def get_params(self, deep=False):
-    """Get parameters for this estimator.
+    """Get parameters for this metric learner.
     
     Parameters
     ----------
@@ -62,7 +62,7 @@ class BaseMetricLearner(object):
     return self.params
     
   def set_params(self, **kwarg):
-    """Set the parameters of this estimator.
+    """Set the parameters of this metric learner.
     
     Overwrites any default parameters or parameters specified in constructor.
     

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -45,3 +45,9 @@ class BaseMetricLearner(object):
       X = self.X
     L = self.transformer()
     return X.dot(L.T)
+
+    def get_params(self, deep=False):
+        return self.params
+    
+    def set_params(self, **kwarg):
+        self.params = {**kwarg, **self.params}

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -47,7 +47,27 @@ class BaseMetricLearner(object):
     return X.dot(L.T)
 
   def get_params(self, deep=False):
+    """Get parameters for this estimator.
+    
+    Parameters
+    ----------
+    deep: boolean, optional
+        @WARNING doesn't do anything, only exists because scikit-learn has this on BaseEstimator.
+    
+    Returns
+    -------
+    params : mapping of string to any
+        Parameter names mapped to their values.
+    """
     return self.params
     
   def set_params(self, **kwarg):
+    """Set the parameters of this estimator.
+    
+    Overwrites any default parameters or parameters specified in constructor.
+    
+    Returns
+    -------
+    self
+    """
     self.params = {**self.params, **kwarg}

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -50,4 +50,4 @@ class BaseMetricLearner(object):
     return self.params
     
   def set_params(self, **kwarg):
-    self.params = {**kwarg, **self.params}
+    self.params = {**self.params, **kwarg}

--- a/metric_learn/base_metric.py
+++ b/metric_learn/base_metric.py
@@ -46,8 +46,8 @@ class BaseMetricLearner(object):
     L = self.transformer()
     return X.dot(L.T)
 
-    def get_params(self, deep=False):
-        return self.params
+  def get_params(self, deep=False):
+    return self.params
     
-    def set_params(self, **kwarg):
-        self.params = {**kwarg, **self.params}
+  def set_params(self, **kwarg):
+    self.params = {**kwarg, **self.params}

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -30,9 +30,11 @@ class ITML(BaseMetricLearner):
     max_iters : int, optional
     convergence_threshold : float, optional
     """
-    self.gamma = gamma
-    self.max_iters = max_iters
-    self.convergence_threshold = convergence_threshold
+    self.params = {
+      'gamma': gamma,
+      'max_iters': max_iters,
+      'convergence_threshold': convergence_threshold,
+    }
 
   def _process_inputs(self, X, constraints, bounds, A0):
     self.X = X
@@ -70,7 +72,7 @@ class ITML(BaseMetricLearner):
         initial regularization matrix, defaults to identity
     """
     a,b,c,d = self._process_inputs(X, constraints, bounds, A0)
-    gamma = self.gamma
+    gamma = self.params['gamma']
     num_pos = len(a)
     num_neg = len(c)
     _lambda = np.zeros(num_pos + num_neg)
@@ -80,7 +82,7 @@ class ITML(BaseMetricLearner):
     neg_bhat = np.zeros(num_neg) + self.bounds[1]
     A = self.A
 
-    for it in xrange(self.max_iters):
+    for it in xrange(self.params['max_iters']):
       # update positives
       vv = self.X[a] - self.X[b]
       for i,v in enumerate(vv):
@@ -106,7 +108,7 @@ class ITML(BaseMetricLearner):
         conv = np.inf
         break
       conv = np.abs(lambdaold - _lambda).sum() / normsum
-      if conv < self.convergence_threshold:
+      if conv < self.params['convergence_threshold']:
         break
       lambdaold = _lambda.copy()
       if verbose:

--- a/metric_learn/lfda.py
+++ b/metric_learn/lfda.py
@@ -112,6 +112,7 @@ class LFDA(BaseMetricLearner):
        vecs, _ = np.linalg.qr(vecs)
 
     self._transformer = vecs.T
+    return self
 
 
 def _sum_outer(x):

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -24,8 +24,10 @@ class LSML(BaseMetricLearner):
     tol : float, optional
     max_iter : int, optional
     """
-    self.tol = tol
-    self.max_iter = max_iter
+    self.params = {
+      'tol': tol,
+      'max_iter': max_iter,
+    }
 
   def _prepare_inputs(self, X, constraints, weights, prior):
     self.X = X
@@ -66,10 +68,10 @@ class LSML(BaseMetricLearner):
     step_sizes = np.logspace(-10, 0, 10)
     if verbose:
       print('initial loss', s_best)
-    for it in xrange(1, self.max_iter+1):
+    for it in xrange(1, self.params['max_iter']+1):
       grad = self._gradient(self.M, prior_inv)
       grad_norm = scipy.linalg.norm(grad)
-      if grad_norm < self.tol:
+      if grad_norm < self.params['tol']:
         break
       if verbose:
         print('gradient norm', grad_norm)

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -11,8 +11,10 @@ from .base_metric import BaseMetricLearner
 
 class NCA(BaseMetricLearner):
   def __init__(self, max_iter=100, learning_rate=0.01):
-    self.max_iter = max_iter
-    self.learning_rate = learning_rate
+    self.params = {
+      'max_iter': max_iter,
+      'learning_rate': learning_rate,
+    }
     self.A = None
 
   def transformer(self):
@@ -32,7 +34,7 @@ class NCA(BaseMetricLearner):
     dX = X[:,None] - X[None]  # shape (n, n, d)
     tmp = np.einsum('...i,...j->...ij', dX, dX)  # shape (n, n, d, d)
     masks = labels[:,None] == labels[None]
-    for it in xrange(self.max_iter):
+    for it in xrange(self.params['max_iter']):
       for i, label in enumerate(labels):
         mask = masks[i]
         Ax = A.dot(X.T).T  # shape (n, d)
@@ -43,7 +45,7 @@ class NCA(BaseMetricLearner):
 
         t = softmax[:, None, None] * tmp[i]  # shape (n, d, d)
         d = softmax[mask].sum() * t.sum(axis=0) - t[mask].sum(axis=0)
-        A += self.learning_rate * A.dot(d)
+        A += self.params['learning_rate'] * A.dot(d)
 
     self.X = X
     self.A = A

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -27,7 +27,9 @@ class RCA(BaseMetricLearner):
     dim : int, optional
         embedding dimension (default: original dimension of data)
     """
-    self.dim = dim
+    self.params = {
+      'dim': dim,
+    }
 
   def transformer(self):
     return self._transformer
@@ -37,9 +39,9 @@ class RCA(BaseMetricLearner):
     self.X = X
     n, d = X.shape
 
-    if self.dim is None:
-      self.dim = d
-    elif not 0 < self.dim <= d:
+    if self.params['dim'] is None:
+      self.params['dim'] = d
+    elif not 0 < self.params['dim'] <= d:
       raise ValueError('Invalid embedding dimension, must be in [1,%d]' % d)
 
     Y = np.asanyarray(Y)
@@ -75,11 +77,11 @@ class RCA(BaseMetricLearner):
     inner_cov = np.cov(chunk_data, rowvar=0, bias=1)
 
     # Fisher Linear Discriminant projection
-    if self.dim < d:
+    if self.params['dim'] < d:
       total_cov = np.cov(data[chunk_mask], rowvar=0)
       tmp = np.linalg.lstsq(total_cov, inner_cov)[0]
       vals, vecs = np.linalg.eig(tmp)
-      inds = np.argsort(vals)[:self.dim]
+      inds = np.argsort(vals)[:self.params['dim']]
       A = vecs[:,inds]
       inner_cov = A.T.dot(inner_cov).dot(A)
       self._transformer = _inv_sqrtm(inner_cov).dot(A.T)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -23,14 +23,16 @@ class SDML(BaseMetricLearner):
     balance_param: trade off between sparsity and M0 prior
     sparsity_param: trade off between optimizer and sparseness (see graph_lasso)
     '''
-    self.balance_param = balance_param
-    self.sparsity_param = sparsity_param
-    self.use_cov = use_cov
+    self.params = {
+      'balance_param': balance_param,
+      'sparsity_param': sparsity_param,
+      'use_cov': use_cov,
+    }
 
   def _prepare_inputs(self, X, W):
     self.X = X
     # set up prior M
-    if self.use_cov:
+    if self.params['use_cov']:
       self.M = np.cov(X.T)
     else:
       self.M = np.identity(X.shape[1])
@@ -46,11 +48,11 @@ class SDML(BaseMetricLearner):
     W: connectivity graph, (n x n). +1 for positive pairs, -1 for negative.
     """
     self._prepare_inputs(X, W)
-    P = pinvh(self.M) + self.balance_param * self.loss_matrix
+    P = pinvh(self.M) + self.params['balance_param'] * self.loss_matrix
     emp_cov = pinvh(P)
     # hack: ensure positive semidefinite
     emp_cov = emp_cov.T.dot(emp_cov)
-    self.M, _ = graph_lasso(emp_cov, self.sparsity_param, verbose=verbose)
+    self.M, _ = graph_lasso(emp_cov, self.params['sparsity_param'], verbose=verbose)
     return self
 
   @classmethod


### PR DESCRIPTION
I wanted to use the metric-learners in a scikit Pipeline and GridSearchCV. GridSeachCV uses get_params and set_params and so I implemented both methods on the BaseMetricLearner.

Consequently I had to move all learner parameters to dictionaries so that these two methods would get to their params.