### PR TITLE
Fit constraints

### DIFF
--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import
 
 from .itml import ITML
+from .itml import ITML_Supervised
 from .lmnn import LMNN
 from .lsml import LSML
+from .lsml import LSML_Supervised
 from .sdml import SDML
+from .sdml import SDML_Supervised
 from .nca import NCA
 from .lfda import LFDA
 from .rca import RCA
+from .rca import RCA_Supervised
+from .constraints import Constraints

--- a/metric_learn/__init__.py
+++ b/metric_learn/__init__.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import
 
-from .itml import ITML
-from .itml import ITML_Supervised
+from .itml import ITML, ITML_Supervised
 from .lmnn import LMNN
-from .lsml import LSML
-from .lsml import LSML_Supervised
-from .sdml import SDML
-from .sdml import SDML_Supervised
+from .lsml import LSML, LSML_Supervised
+from .sdml import SDML, SDML_Supervised
 from .nca import NCA
 from .lfda import LFDA
-from .rca import RCA
-from .rca import RCA_Supervised
-from .constraints import Constraints
+from .rca import RCA, RCA_Supervised
+from .constraints import adjacencyMatrix, positiveNegativePairs, relativeQuadruplets, chunks

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -1,0 +1,61 @@
+import random
+import numpy as np
+from six.moves import xrange
+
+class Constraints(object):
+
+  @staticmethod
+  def adjacencyMatrix(labels, num_points, num_constraints):
+    a, c = np.random.randint(len(labels), size=(2,num_constraints))
+    b, d = np.empty((2, num_constraints), dtype=int)
+    for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
+      b[i] = random.choice(np.nonzero(labels == al)[0])
+      d[i] = random.choice(np.nonzero(labels != cl)[0])
+    W = np.zeros((num_points,num_points))
+    W[a,b] = 1
+    W[c,d] = -1
+    # make W symmetric
+    W[b,a] = 1
+    W[d,c] = -1
+    return W
+
+  @staticmethod
+  def positiveNegativePairs(labels, num_points, num_constraints):
+    ac,bd = np.random.randint(num_points, size=(2,num_constraints))
+    pos = labels[ac] == labels[bd]
+    a,c = ac[pos], ac[~pos]
+    b,d = bd[pos], bd[~pos]
+    return a,b,c,d
+
+  @staticmethod
+  def relativeQuadruplets(labels, num_constraints):
+    C = np.empty((num_constraints,4), dtype=int)
+    a, c = np.random.randint(len(labels), size=(2,num_constraints))
+    for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
+      C[i,1] = random.choice(np.nonzero(labels == al)[0])
+      C[i,3] = random.choice(np.nonzero(labels != cl)[0])
+    C[:,0] = a
+    C[:,2] = c
+    return C
+
+  @staticmethod
+  def chunks(Y, num_chunks=100, chunk_size=2, seed=None):
+    random.seed(seed)
+    chunks = -np.ones_like(Y, dtype=int)
+    uniq, lookup = np.unique(Y, return_inverse=True)
+    all_inds = [set(np.where(lookup==c)[0]) for c in xrange(len(uniq))]
+    idx = 0
+    while idx < num_chunks and all_inds:
+      c = random.randint(0, len(all_inds)-1)
+      inds = all_inds[c]
+      if len(inds) < chunk_size:
+        del all_inds[c]
+        continue
+      ii = random.sample(inds, chunk_size)
+      inds.difference_update(ii)
+      chunks[ii] = idx
+      idx += 1
+    if idx < num_chunks:
+      raise ValueError('Unable to make %d chunks of %d examples each' %
+                       (num_chunks, chunk_size))
+    return chunks

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -1,3 +1,5 @@
+""" Helper class that can generate different types of constraints from supervised data labels."""
+
 import random
 import numpy as np
 from six.moves import xrange

--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -1,63 +1,62 @@
 """ Helper class that can generate different types of constraints from supervised data labels."""
 
-import random
 import numpy as np
+import random
 from six.moves import xrange
 
-class Constraints(object):
+# @TODO: consider creating a stateful class
+# https://github.com/all-umass/metric-learn/pull/19#discussion_r67386226
 
-  @staticmethod
-  def adjacencyMatrix(labels, num_points, num_constraints):
-    a, c = np.random.randint(len(labels), size=(2,num_constraints))
-    b, d = np.empty((2, num_constraints), dtype=int)
-    for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
-      b[i] = random.choice(np.nonzero(labels == al)[0])
-      d[i] = random.choice(np.nonzero(labels != cl)[0])
-    W = np.zeros((num_points,num_points))
-    W[a,b] = 1
-    W[c,d] = -1
-    # make W symmetric
-    W[b,a] = 1
-    W[d,c] = -1
-    return W
+def adjacencyMatrix(labels, num_points, num_constraints):
+  a, c = np.random.randint(len(labels), size=(2,num_constraints))
+  b, d = np.empty((2, num_constraints), dtype=int)
+  for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
+    b[i] = random.choice(np.nonzero(labels == al)[0])
+    d[i] = random.choice(np.nonzero(labels != cl)[0])
+  W = np.zeros((num_points,num_points))
+  W[a,b] = 1
+  W[c,d] = -1
+  # make W symmetric
+  W[b,a] = 1
+  W[d,c] = -1
+  return W
 
-  @staticmethod
-  def positiveNegativePairs(labels, num_points, num_constraints):
-    ac,bd = np.random.randint(num_points, size=(2,num_constraints))
-    pos = labels[ac] == labels[bd]
-    a,c = ac[pos], ac[~pos]
-    b,d = bd[pos], bd[~pos]
-    return a,b,c,d
+def positiveNegativePairs(labels, num_points, num_constraints):
+  ac,bd = np.random.randint(num_points, size=(2,num_constraints))
+  pos = labels[ac] == labels[bd]
+  a,c = ac[pos], ac[~pos]
+  b,d = bd[pos], bd[~pos]
+  return a,b,c,d
 
-  @staticmethod
-  def relativeQuadruplets(labels, num_constraints):
-    C = np.empty((num_constraints,4), dtype=int)
-    a, c = np.random.randint(len(labels), size=(2,num_constraints))
-    for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
-      C[i,1] = random.choice(np.nonzero(labels == al)[0])
-      C[i,3] = random.choice(np.nonzero(labels != cl)[0])
-    C[:,0] = a
-    C[:,2] = c
-    return C
+def relativeQuadruplets(labels, num_constraints):
+  C = np.empty((num_constraints,4), dtype=int)
+  a, c = np.random.randint(len(labels), size=(2,num_constraints))
+  for i,(al,cl) in enumerate(zip(labels[a],labels[c])):
+    C[i,1] = random.choice(np.nonzero(labels == al)[0])
+    C[i,3] = random.choice(np.nonzero(labels != cl)[0])
+  C[:,0] = a
+  C[:,2] = c
+  return C
 
-  @staticmethod
-  def chunks(Y, num_chunks=100, chunk_size=2, seed=None):
-    random.seed(seed)
-    chunks = -np.ones_like(Y, dtype=int)
-    uniq, lookup = np.unique(Y, return_inverse=True)
-    all_inds = [set(np.where(lookup==c)[0]) for c in xrange(len(uniq))]
-    idx = 0
-    while idx < num_chunks and all_inds:
-      c = random.randint(0, len(all_inds)-1)
-      inds = all_inds[c]
-      if len(inds) < chunk_size:
-        del all_inds[c]
-        continue
-      ii = random.sample(inds, chunk_size)
-      inds.difference_update(ii)
-      chunks[ii] = idx
-      idx += 1
-    if idx < num_chunks:
-      raise ValueError('Unable to make %d chunks of %d examples each' %
-                       (num_chunks, chunk_size))
-    return chunks
+def chunks(Y, num_chunks=100, chunk_size=2, seed=None):
+  # @TODO: remove seed from params and use numpy RandomState
+  # https://github.com/all-umass/metric-learn/pull/19#discussion_r67386666
+  random.seed(seed)
+  chunks = -np.ones_like(Y, dtype=int)
+  uniq, lookup = np.unique(Y, return_inverse=True)
+  all_inds = [set(np.where(lookup==c)[0]) for c in xrange(len(uniq))]
+  idx = 0
+  while idx < num_chunks and all_inds:
+    c = random.randint(0, len(all_inds)-1)
+    inds = all_inds[c]
+    if len(inds) < chunk_size:
+      del all_inds[c]
+      continue
+    ii = random.sample(inds, chunk_size)
+    inds.difference_update(ii)
+    chunks[ii] = idx
+    idx += 1
+  if idx < num_chunks:
+    raise ValueError('Unable to make %d chunks of %d examples each' %
+                     (num_chunks, chunk_size))
+  return chunks

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -78,8 +78,7 @@ class ITML(BaseMetricLearner):
       raise ValueError('You need to specify `num_constraints` before using .fit()')
 
     C = self.prepare_constraints(labels, X.shape[0], num_constraints)
-    self.fit_constraints(X, C, bounds=self.params['bounds'], A0=self.params['A0'], verbose=self.params['verbose'])
-    return self
+    return self.fit_constraints(X, C, bounds=self.params['bounds'], A0=self.params['A0'], verbose=self.params['verbose'])
 
   def fit_constraints(self, X, constraints, bounds=None, A0=None, verbose=False):
     """Learn the ITML model.

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -155,11 +155,11 @@ class ITML_Supervised(ITML):
     """
     ITML.__init__(self, gamma=gamma, max_iters=max_iters, 
       convergence_threshold=convergence_threshold, verbose=verbose)
-    self.params = {
+    self.params.update({
       'num_constraints': num_constraints,
       'bounds': bounds,
       'A0': A0,
-    }
+    })
 
   def fit(self, X, labels):
     """Create constraints from labels and learn the ITML model.

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -178,4 +178,4 @@ class ITML_Supervised(ITML):
       num_constraints = 20*(len(set(labels)))**2 # 20* number of classes**2
 
     C = Constraints.positiveNegativePairs(labels, X.shape[0], num_constraints)
-    return super().fit(X, C, bounds=self.params['bounds'], A0=self.params['A0'])
+    return super(ITML_Supervised,self).fit(X, C, bounds=self.params['bounds'], A0=self.params['A0'])

--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -16,7 +16,7 @@ import numpy as np
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
 from .base_metric import BaseMetricLearner
-from .constraints import Constraints
+from .constraints import positiveNegativePairs
 
 
 class ITML(BaseMetricLearner):
@@ -153,12 +153,10 @@ class ITML_Supervised(ITML):
     verbose : bool, optional
         if True, prints information while learning
     """
+    ITML.__init__(self, gamma=gamma, max_iters=max_iters, 
+      convergence_threshold=convergence_threshold, verbose=verbose)
     self.params = {
-      'gamma': gamma,
-      'max_iters': max_iters,
-      'convergence_threshold': convergence_threshold,
       'num_constraints': num_constraints,
-      'verbose': verbose,
       'bounds': bounds,
       'A0': A0,
     }
@@ -175,7 +173,8 @@ class ITML_Supervised(ITML):
     """
     num_constraints = self.params['num_constraints']
     if num_constraints is None:
-      num_constraints = 20*(len(set(labels)))**2 # 20* number of classes**2
+      num_classes = np.unique(labels)
+      num_constraints = 20*(len(num_classes))**2
 
-    C = Constraints.positiveNegativePairs(labels, X.shape[0], num_constraints)
-    return super(ITML_Supervised,self).fit(X, C, bounds=self.params['bounds'], A0=self.params['A0'])
+    C = positiveNegativePairs(labels, X.shape[0], num_constraints)
+    return ITML.fit(self, X, C, bounds=self.params['bounds'], A0=self.params['A0'])

--- a/metric_learn/lmnn.py
+++ b/metric_learn/lmnn.py
@@ -29,7 +29,7 @@ class _base_LMNN(BaseMetricLearner):
 # slower Python version
 class python_LMNN(_base_LMNN):
   def __init__(self, k=3, min_iter=50, max_iter=1000, learn_rate=1e-7,
-               regularization=0.5, convergence_tol=0.001):
+               regularization=0.5, convergence_tol=0.001, verbose=False):
     """Initialize the LMNN object
 
     k: number of neighbors to consider. (does not include self-edges)
@@ -37,7 +37,7 @@ class python_LMNN(_base_LMNN):
     """
     _base_LMNN.__init__(self, k=k, min_iter=min_iter, max_iter=max_iter,
                         learn_rate=learn_rate, regularization=regularization,
-                        convergence_tol=convergence_tol)
+                        convergence_tol=convergence_tol, verbose=verbose)
 
   def _process_inputs(self, X, labels):
     num_pts = X.shape[0]
@@ -51,8 +51,9 @@ class python_LMNN(_base_LMNN):
         'not enough class labels for specified k'
         ' (smallest class has %d)' % required_k)
 
-  def fit(self, X, labels, verbose=False):
+  def fit(self, X, labels):
     k = self.params['k']
+    verbose = self.params['verbose']
     reg = self.params['regularization']
     learn_rate = self.params['learn_rate']
     convergence_tol = self.params['convergence_tol']
@@ -236,12 +237,12 @@ try:
 
   class LMNN(_base_LMNN):
     def __init__(self, k=3, min_iter=50, max_iter=1000, learn_rate=1e-7,
-                 regularization=0.5, convergence_tol=0.001, use_pca=True):
+                 regularization=0.5, convergence_tol=0.001, use_pca=True, verbose=False):
       _base_LMNN.__init__(self, k=k, min_iter=min_iter, max_iter=max_iter,
                           learn_rate=learn_rate, regularization=regularization,
-                          convergence_tol=convergence_tol, use_pca=use_pca)
+                          convergence_tol=convergence_tol, use_pca=use_pca, verbose=verbose)
 
-    def fit(self, X, labels, verbose=False):
+    def fit(self, X, labels):
       self.X = X
       self.L = np.eye(X.shape[1])
       labels = MulticlassLabels(labels.astype(np.float64))

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -144,11 +144,11 @@ class LSML_Supervised(LSML):
         if True, prints information while learning
     """
     LSML.__init__(self, tol=tol, max_iter=max_iter, verbose=verbose)
-    self.params = {
+    self.params.update({
       'prior': prior,
       'num_constraints': num_constraints,
       'weights': weights,
-    }
+    })
 
   def fit(self, X, labels):
     """Create constraints from labels and learn the LSML model.

--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -169,4 +169,4 @@ class LSML_Supervised(LSML):
       num_constraints = 20*(len(set(labels)))**2 # 20* number of classes**2
 
     C = Constraints.relativeQuadruplets(labels, num_constraints)
-    return super().fit(X, C, weights=self.params['weights'], prior=self.params['prior'])
+    return super(LSML_Supervised,self).fit(X, C, weights=self.params['weights'], prior=self.params['prior'])

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -15,7 +15,7 @@ import numpy as np
 import random
 from six.moves import xrange
 from .base_metric import BaseMetricLearner
-from .constraints import Constraints
+from .constraints import chunks
 
 
 class RCA(BaseMetricLearner):
@@ -113,8 +113,9 @@ class RCA_Supervised(RCA):
     chunk_size: int, optional
     seed: int, optional
     """
+    # @TODO: remove seed from param. See @TODO in constraints/chunks
+    RCA.__init__(self, dim=dim)
     self.params = {
-      'dim': dim,
       'num_chunks': 100 if num_chunks is None else num_chunks,
       'chunk_size': 2 if chunk_size is None else chunk_size,
       'seed': seed,
@@ -130,5 +131,5 @@ class RCA_Supervised(RCA):
         each row corresponds to a single instance
     labels : (n) data labels
     """
-    C = Constraints.chunks(labels, self.params['num_chunks'], self.params['chunk_size'], self.params['seed'])
-    return super(RCA_Supervised,self).fit(X, C)
+    C = chunks(labels, self.params['num_chunks'], self.params['chunk_size'], self.params['seed'])
+    return RCA.fit(self, X, C)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -131,4 +131,4 @@ class RCA_Supervised(RCA):
     labels : (n) data labels
     """
     C = Constraints.chunks(labels, self.params['num_chunks'], self.params['chunk_size'], self.params['seed'])
-    return super().fit(X, C)
+    return super(RCA_Supervised,self).fit(X, C)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -115,11 +115,11 @@ class RCA_Supervised(RCA):
     """
     # @TODO: remove seed from param. See @TODO in constraints/chunks
     RCA.__init__(self, dim=dim)
-    self.params = {
+    self.params.update({
       'num_chunks': 100 if num_chunks is None else num_chunks,
       'chunk_size': 2 if chunk_size is None else chunk_size,
       'seed': seed,
-    }
+    })
 
   def fit(self, X, labels):
     """Create constraints from labels and learn the LSML model.

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -94,4 +94,4 @@ class SDML_Supervised(SDML):
       num_constraints = 20*(len(set(labels)))**2 # 20* number of classes**2
 
     W = Constraints.adjacencyMatrix(labels, X.shape[0], num_constraints)
-    return super().fit(X, W)
+    return super(SDML_Supervised,self).fit(X, W)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -15,7 +15,7 @@ from scipy.sparse.csgraph import laplacian
 from sklearn.covariance import graph_lasso
 from sklearn.utils.extmath import pinvh
 from .base_metric import BaseMetricLearner
-from .constraints import Constraints
+from .constraints import adjacencyMatrix
 
 
 class SDML(BaseMetricLearner):
@@ -71,13 +71,8 @@ class SDML_Supervised(SDML):
     verbose : bool, optional
         if True, prints information while learning
     '''
-    self.params = {
-      'balance_param': balance_param,
-      'sparsity_param': sparsity_param,
-      'use_cov': use_cov,
-      'num_constraints': num_constraints,
-      'verbose': verbose,
-    }
+    SDML.__init__(self, balance_param=balance_param, sparsity_param=sparsity_param, use_cov=use_cov, verbose=verbose)
+    self.params['num_constraints'] = num_constraints
 
   def fit(self, X, labels):
     """Create constraints from labels and learn the SDML model.
@@ -91,7 +86,8 @@ class SDML_Supervised(SDML):
     """
     num_constraints = self.params['num_constraints']
     if num_constraints is None:
-      num_constraints = 20*(len(set(labels)))**2 # 20* number of classes**2
+      num_classes = np.unique(labels)
+      num_constraints = 20*(len(num_classes))**2
 
-    W = Constraints.adjacencyMatrix(labels, X.shape[0], num_constraints)
-    return super(SDML_Supervised,self).fit(X, W)
+    W = adjacencyMatrix(labels, X.shape[0], num_constraints)
+    return SDML.fit(self, X, W)

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -79,19 +79,6 @@ class SDML_Supervised(SDML):
       'verbose': verbose,
     }
 
-  def _prepare_inputs(self, X, W):
-    self.X = X
-    # set up prior M
-    if self.params['use_cov']:
-      self.M = np.cov(X.T)
-    else:
-      self.M = np.identity(X.shape[1])
-    L = laplacian(W, normed=False)
-    self.loss_matrix = self.X.T.dot(L.dot(self.X))
-
-  def metric(self):
-    return self.M
-
   def fit(self, X, labels):
     """Create constraints from labels and learn the SDML model.
     Needs num_constraints specified in constructor.

--- a/metric_learn/sdml.py
+++ b/metric_learn/sdml.py
@@ -62,8 +62,7 @@ class SDML(BaseMetricLearner):
       raise ValueError('You need to specify `num_constraints` before using .fit()')
 
     W = self.prepare_constraints(labels, X.shape[0], num_constraints)
-    self.fit_constraints(X, W, verbose=self.params['verbose'])
-    return self
+    return self.fit_constraints(X, W, verbose=self.params['verbose'])
 
   def fit_constraints(self, X, W, verbose=False):
     """

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -36,7 +36,7 @@ class TestLSML(MetricTestCase):
     num_constraints = 200
 
     C = LSML.prepare_constraints(self.iris_labels, num_constraints)
-    lsml = LSML().fit(self.iris_points, C, verbose=False)
+    lsml = LSML().fit_constraints(self.iris_points, C, verbose=False)
 
     csep = class_separation(lsml.transform(), self.iris_labels)
     self.assertLess(csep, 0.8)  # it's pretty terrible
@@ -48,7 +48,7 @@ class TestITML(MetricTestCase):
 
     n = self.iris_points.shape[0]
     C = ITML.prepare_constraints(self.iris_labels, n, num_constraints)
-    itml = ITML().fit(self.iris_points, C, verbose=False)
+    itml = ITML().fit_constraints(self.iris_points, C, verbose=False)
 
     csep = class_separation(itml.transform(), self.iris_labels)
     self.assertLess(csep, 0.4)  # it's not great
@@ -79,7 +79,7 @@ class TestSDML(MetricTestCase):
 
     # Test sparse graph inputs.
     for graph in ((W, scipy.sparse.csr_matrix(W))):
-      sdml = SDML().fit(self.iris_points, graph)
+      sdml = SDML().fit_constraints(self.iris_points, graph)
       csep = class_separation(sdml.transform(), self.iris_labels)
       self.assertLess(csep, 0.25)
 
@@ -112,7 +112,7 @@ class TestRCA(MetricTestCase):
     rca = RCA(dim=2)
     chunks = RCA.prepare_constraints(self.iris_labels, num_chunks=30,
                                      chunk_size=2, seed=1234)
-    rca.fit(self.iris_points, chunks)
+    rca.fit_constraints(self.iris_points, chunks)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.25)
 

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -58,8 +58,8 @@ class TestLMNN(MetricTestCase):
 
     # Test both impls, if available.
     for LMNN_cls in set((LMNN, python_LMNN)):
-      lmnn = LMNN_cls(k=k, learn_rate=1e-6)
-      lmnn.fit(self.iris_points, self.iris_labels, verbose=False)
+      lmnn = LMNN_cls(k=k, learn_rate=1e-6, verbose=False)
+      lmnn.fit(self.iris_points, self.iris_labels)
 
       csep = class_separation(lmnn.transform(), self.iris_labels)
       self.assertLess(csep, 0.25)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -6,7 +6,8 @@ from sklearn.metrics import pairwise_distances
 from sklearn.datasets import load_iris
 from numpy.testing import assert_array_almost_equal
 
-from metric_learn import LSML, ITML, LMNN, SDML, NCA, LFDA, RCA
+from metric_learn import LSML_Supervised, ITML_Supervised, SDML_Supervised, RCA_Supervised
+from metric_learn import LMNN, NCA, LFDA
 # Import this specially for testing.
 from metric_learn.lmnn import python_LMNN
 
@@ -35,8 +36,7 @@ class TestLSML(MetricTestCase):
   def test_iris(self):
     num_constraints = 200
 
-    C = LSML.prepare_constraints(self.iris_labels, num_constraints)
-    lsml = LSML().fit_constraints(self.iris_points, C, verbose=False)
+    lsml = LSML_Supervised(num_constraints=num_constraints).fit(self.iris_points, self.iris_labels)
 
     csep = class_separation(lsml.transform(), self.iris_labels)
     self.assertLess(csep, 0.8)  # it's pretty terrible
@@ -46,9 +46,7 @@ class TestITML(MetricTestCase):
   def test_iris(self):
     num_constraints = 200
 
-    n = self.iris_points.shape[0]
-    C = ITML.prepare_constraints(self.iris_labels, n, num_constraints)
-    itml = ITML().fit_constraints(self.iris_points, C, verbose=False)
+    itml = ITML_Supervised(num_constraints=num_constraints).fit(self.iris_points, self.iris_labels)
 
     csep = class_separation(itml.transform(), self.iris_labels)
     self.assertLess(csep, 0.4)  # it's not great
@@ -71,17 +69,13 @@ class TestSDML(MetricTestCase):
   def test_iris(self):
     num_constraints = 1500
 
-    n = self.iris_points.shape[0]
     # Note: this is a flaky test, which fails for certain seeds.
     # TODO: un-flake it!
     np.random.seed(5555)
-    W = SDML.prepare_constraints(self.iris_labels, n, num_constraints)
 
-    # Test sparse graph inputs.
-    for graph in ((W, scipy.sparse.csr_matrix(W))):
-      sdml = SDML().fit_constraints(self.iris_points, graph)
-      csep = class_separation(sdml.transform(), self.iris_labels)
-      self.assertLess(csep, 0.25)
+    sdml = SDML_Supervised(num_constraints=num_constraints).fit(self.iris_points, self.iris_labels)
+    csep = class_separation(sdml.transform(), self.iris_labels)
+    self.assertLess(csep, 0.25)
 
 
 class TestNCA(MetricTestCase):
@@ -109,10 +103,8 @@ class TestLFDA(MetricTestCase):
 
 class TestRCA(MetricTestCase):
   def test_iris(self):
-    rca = RCA(dim=2)
-    chunks = RCA.prepare_constraints(self.iris_labels, num_chunks=30,
-                                     chunk_size=2, seed=1234)
-    rca.fit_constraints(self.iris_points, chunks)
+    rca = RCA_Supervised(dim=2, num_chunks=30, chunk_size=2, seed=1234)
+    rca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.25)
 


### PR DESCRIPTION
I needed to use the Metric Learners inside scikit Pipeline, which only calls .fit(X,y).

Therefore I renamed original .fit() to .fit_constraints(), added all of its parameters to constructor and created new .fit(), which uses the parameters from constructor to build constraints and then call .fit_constraints().

I understand this is a breaking change. If there is a better approach I want to hear it :)

This only affects methods which need special constraints: ITML, SDML, LSML, RCA