### PR TITLE
Removed random import

### DIFF
--- a/metric_learn/constraints.py
+++ b/metric_learn/constraints.py
@@ -3,7 +3,6 @@ Helper module for generating different types of constraints
 from supervised data labels.
 """
 import numpy as np
-import random
 import warnings
 from six.moves import xrange
 from scipy.sparse import coo_matrix


### PR DESCRIPTION
Removed the `random` import as we've now completely shifted to the numpy random class for any random functions.