### PR TITLE
Nca

### DIFF
--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -9,6 +9,7 @@ from six.moves import xrange
 
 from .base_metric import BaseMetricLearner
 
+EPS = np.finfo(float).eps
 
 class NCA(BaseMetricLearner):
   def __init__(self, max_iter=100, learning_rate=0.01):
@@ -29,7 +30,7 @@ class NCA(BaseMetricLearner):
     n, d = X.shape
     # Initialize A to a scaling matrix
     A = np.zeros((d, d))
-    np.fill_diagonal(A, 1./(X.max(axis=0)-X.min(axis=0)))
+    np.fill_diagonal(A, 1./(np.maximum(X.max(axis=0)-X.min(axis=0), EPS)))
 
     # Run NCA
     dX = X[:,None] - X[None]  # shape (n, n, d)

--- a/metric_learn/nca.py
+++ b/metric_learn/nca.py
@@ -12,8 +12,9 @@ from .base_metric import BaseMetricLearner
 EPS = np.finfo(float).eps
 
 class NCA(BaseMetricLearner):
-  def __init__(self, max_iter=100, learning_rate=0.01):
+  def __init__(self, num_dims=None, max_iter=100, learning_rate=0.01):
     self.params = {
+      'num_dims': num_dims,
       'max_iter': max_iter,
       'learning_rate': learning_rate,
     }
@@ -28,8 +29,11 @@ class NCA(BaseMetricLearner):
     labels: scalar labels, (n)
     """
     n, d = X.shape
+    num_dims = self.params['num_dims']
+    if num_dims is None:
+        num_dims = d
     # Initialize A to a scaling matrix
-    A = np.zeros((d, d))
+    A = np.zeros((num_dims, d))
     np.fill_diagonal(A, 1./(np.maximum(X.max(axis=0)-X.min(axis=0), EPS)))
 
     # Run NCA
@@ -40,7 +44,7 @@ class NCA(BaseMetricLearner):
     for it in xrange(self.params['max_iter']):
       for i, label in enumerate(labels):
         mask = masks[i]
-        Ax = A.dot(X.T).T  # shape (n, d)
+        Ax = A.dot(X.T).T  # shape (n, num_dims)
 
         softmax = np.exp(-((Ax[i] - Ax)**2).sum(axis=1))  # shape (n)
         softmax[i] = 0

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -86,9 +86,10 @@ class TestSDML(MetricTestCase):
 class TestNCA(MetricTestCase):
   def test_iris(self):
     n = self.iris_points.shape[0]
+
+    # Without dimension reduction
     nca = NCA(max_iter=(100000//n), learning_rate=0.01)
     nca.fit(self.iris_points, self.iris_labels)
-
     # Result copied from Iris example at
     # https://github.com/vomjom/nca/blob/master/README.mkd
     expected = [[-0.09935, -0.2215,  0.3383,  0.443],
@@ -96,6 +97,12 @@ class TestNCA(MetricTestCase):
                 [-0.729,   -0.6386,  1.767,   1.832],
                 [-0.9405,  -0.8461,  2.281,   2.794]]
     assert_array_almost_equal(expected, nca.transformer(), decimal=3)
+
+    # With dimension reduction
+    nca = NCA(max_iter=(100000//n), learning_rate=0.01, num_dims=2)
+    nca.fit(self.iris_points, self.iris_labels)
+    csep = class_separation(nca.transform(), self.iris_labels)
+    self.assertLess(csep, 0.15)
 
 
 class TestLFDA(MetricTestCase):


### PR DESCRIPTION
1) The current implementation of NCA does not work when the variance of a feature is null. Indeed, the matrix A is then initialized with some nan values (1 / max - min is undefined).
I propose to initialize A with 1 / max(max - min, EPS). This solution is similar to the one used in MLKR.

2) The current implementation of NCA does not support dimension reduction. I propose to:
     - Add a parameter num_dim to the constructor (as in MLKR)
     - Initialize A with a matrix of dimension (num_dim, d)