### PR TITLE
Fixes ITML performance 

### DIFF
--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -101,7 +101,8 @@ class ITML(BaseMetricLearner):
         _lambda[i] -= alpha
         beta = alpha/(1 - alpha*wtw)
         pos_bhat[i] = 1./((1 / pos_bhat[i]) + (alpha / gamma))
-        A += beta * A.dot(np.outer(v,v)).dot(A)
+        Av = A.dot(v)
+        A += beta * np.outer(Av, Av)
 
       # update negatives
       vv = self.X[c] - self.X[d]
@@ -111,7 +112,8 @@ class ITML(BaseMetricLearner):
         _lambda[i+num_pos] -= alpha
         beta = -alpha/(1 + alpha*wtw)
         neg_bhat[i] = 1./((1 / neg_bhat[i]) - (alpha / gamma))
-        A += beta * A.dot(np.outer(v,v)).dot(A)
+        Av = A.dot(v)
+        A += beta * np.outer(Av, Av)
 
       normsum = np.linalg.norm(_lambda) + np.linalg.norm(lambdaold)
       if normsum == 0:


### PR DESCRIPTION
This pull request fixes a performance bug in the ITML (Information-Theoretic Metric Learning) code.
I've replaced the formula: A*(v*v)*A with (A*v)*(A*v), which improves the complexity from O(n^3) to O(n^2), as described in the original ITML paper.
note that one mathematical justification is in order, which is A=A' in all stages of the algorithm since A is a Mahalanobis matrix.
I've tested it and got the exact same numerical results, with the fraction of the time needed (hours vs. days).
