### PR TITLE
Handle rank-deficient inner covariance in RCA

### DIFF
--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -103,6 +103,10 @@ class RCA(BaseMetricLearner):
 
     # The embedding dimension must be smaller than the rank of the inner covariance matrix
     dim = min(self.params['dim'], rank)
+    if dim < self.params['dim']:
+      mess  = 'WARNING : The embedding dimension must be smaller than the rank of the inner covariance matrix. '
+      mess += 'dim is set to ' + str(dim) + '.'
+      print mess
 
     # Fisher Linear Discriminant projection
     if dim < rank:

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -8,6 +8,7 @@ Those relevant dimensions are estimated using "chunklets",
 subsets of points that are known to belong to the same class.
 
 'Learning distance functions using equivalence relations', ICML 2003
+'Learning a Mahalanobis metric from equivalence constraints', JMLR 2005
 """
 
 from __future__ import absolute_import

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -98,7 +98,7 @@ class RCA(BaseMetricLearner):
       d = data.shape[1]
       M_pca = pca.components_
     else:
-        data -= data.mean(axis=0)
+      data -= data.mean(axis=0)
 
     chunk_mask, chunk_data = self._process_chunks(data, chunks)
     inner_cov = np.cov(chunk_data, rowvar=0, bias=1)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -33,13 +33,6 @@ def _process_chunks(data, chunks, num_chunks):
 
   return chunk_mask, chunk_data, chunk_labels
 
-# "inner" covariance of chunk deviations
-def _compute_inner_cov(chunk_data):
-  inner_cov = np.cov(chunk_data, rowvar=0, bias=1)
-  rank = np.linalg.matrix_rank(inner_cov)
-
-  return inner_cov, rank
-
 
 class RCA(BaseMetricLearner):
   """Relevant Components Analysis (RCA)"""
@@ -86,7 +79,8 @@ class RCA(BaseMetricLearner):
     """
     data, chunks, num_chunks, d = self._process_inputs(data, chunks)
     chunk_mask, chunk_data, chunk_labels = _process_chunks(data, chunks, num_chunks)
-    inner_cov, rank = _compute_inner_cov(chunk_data)
+    inner_cov = np.cov(chunk_data, rowvar=0, bias=1)
+    rank = np.linalg.matrix_rank(inner_cov)
 
     # If the inner covariance matrix is not full rank,
     # the input data are first projected with a PCA to a space of dimension rank.
@@ -97,7 +91,8 @@ class RCA(BaseMetricLearner):
       M_pca = pca.components_
       data = pca.transform(data)
       chunk_mask, chunk_data, chunk_labels = _process_chunks(data, chunks, num_chunks)
-      inner_cov, rank = _compute_inner_cov(chunk_data)
+      inner_cov = np.cov(chunk_data, rowvar=0, bias=1)
+      rank = np.linalg.matrix_rank(inner_cov)
 
     # The embedding dimension must be smaller than the rank of the inner covariance matrix
     dim = min(self.params['dim'], rank)

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import numpy as np
 from six.moves import xrange
 from sklearn import decomposition
+import warnings
 
 from .base_metric import BaseMetricLearner
 from .constraints import Constraints
@@ -97,9 +98,9 @@ class RCA(BaseMetricLearner):
     # The embedding dimension must be smaller than the rank of the inner covariance matrix
     dim = min(self.params['dim'], rank)
     if dim < self.params['dim']:
-      mess  = 'WARNING : The embedding dimension must be smaller than the rank of the inner covariance matrix. '
+      mess  = 'The embedding dimension must be smaller than the rank of the inner covariance matrix. '
       mess += 'dim is set to ' + str(dim) + '.'
-      print(mess)
+      warnings.warn(mess)
 
     # Fisher Linear Discriminant projection
     if dim < rank:

--- a/metric_learn/rca.py
+++ b/metric_learn/rca.py
@@ -106,7 +106,7 @@ class RCA(BaseMetricLearner):
     if dim < self.params['dim']:
       mess  = 'WARNING : The embedding dimension must be smaller than the rank of the inner covariance matrix. '
       mess += 'dim is set to ' + str(dim) + '.'
-      print mess
+      print(mess)
 
     # Fisher Linear Discriminant projection
     if dim < rank:

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
-from sklearn.datasets import load_iris, load_digits
+from sklearn.datasets import load_iris
 from numpy.testing import assert_array_almost_equal
 
 from metric_learn import (
@@ -29,9 +29,6 @@ class MetricTestCase(unittest.TestCase):
     iris_data = load_iris()
     self.iris_points = iris_data['data']
     self.iris_labels = iris_data['target']
-    digits_data = load_digits()
-    self.digits_points = digits_data['data']
-    self.digits_labels = digits_data['target']
     np.random.seed(1234)
 
 
@@ -122,18 +119,14 @@ class TestRCA(MetricTestCase):
     rca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.25)
+
   def test_feature_null_variance(self):
     rca = RCA_Supervised(dim=2, num_chunks=30, chunk_size=2)
-    X = np.hstack((self.iris_points, 
+    X = np.hstack((self.iris_points,
         np.eye(self.iris_points.shape[0], M = 1)))
     rca.fit(X, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.30)
-  def test_digits(self):
-    rca = RCA_Supervised(dim=3, num_chunks=100, chunk_size=10)
-    rca.fit(self.digits_points, self.digits_labels)
-    csep = class_separation(rca.transform(), self.digits_labels)
-    self.assertLess(csep, 0.40)
 
 
 

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from six.moves import xrange
 from sklearn.metrics import pairwise_distances
-from sklearn.datasets import load_iris
+from sklearn.datasets import load_iris, load_digits
 from numpy.testing import assert_array_almost_equal
 
 from metric_learn import (
@@ -29,6 +29,9 @@ class MetricTestCase(unittest.TestCase):
     iris_data = load_iris()
     self.iris_points = iris_data['data']
     self.iris_labels = iris_data['target']
+    digits_data = load_digits()
+    self.digits_points = digits_data['data']
+    self.digits_labels = digits_data['target']
     np.random.seed(1234)
 
 
@@ -119,6 +122,19 @@ class TestRCA(MetricTestCase):
     rca.fit(self.iris_points, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.25)
+  def test_feature_null_variance(self):
+    rca = RCA_Supervised(dim=2, num_chunks=30, chunk_size=2)
+    X = np.hstack((self.iris_points, 
+        np.eye(self.iris_points.shape[0], M = 1)))
+    rca.fit(X, self.iris_labels)
+    csep = class_separation(rca.transform(), self.iris_labels)
+    self.assertLess(csep, 0.25)
+  def test_digits(self):
+    rca = RCA_Supervised(dim=3, num_chunks=100, chunk_size=10)
+    rca.fit(self.digits_points, self.digits_labels)
+    csep = class_separation(rca.transform(), self.digits_labels)
+    self.assertLess(csep, 0.40)
+
 
 
 class TestMLKR(MetricTestCase):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -121,13 +121,19 @@ class TestRCA(MetricTestCase):
     self.assertLess(csep, 0.25)
 
   def test_feature_null_variance(self):
+    X = np.hstack((self.iris_points, np.eye(len(self.iris_points), M = 1)))
+
+    # Apply PCA with the number of components
     rca = RCA_Supervised(dim=2, pca_comps=3, num_chunks=30, chunk_size=2)
-    X = np.hstack((self.iris_points,
-        np.eye(self.iris_points.shape[0], M = 1)))
     rca.fit(X, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
     self.assertLess(csep, 0.30)
 
+    # Apply PCA with the minimum variance ratio
+    rca = RCA_Supervised(dim=2, pca_comps=0.95, num_chunks=30, chunk_size=2)
+    rca.fit(X, self.iris_labels)
+    csep = class_separation(rca.transform(), self.iris_labels)
+    self.assertLess(csep, 0.30)
 
 
 class TestMLKR(MetricTestCase):

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -121,7 +121,7 @@ class TestRCA(MetricTestCase):
     self.assertLess(csep, 0.25)
 
   def test_feature_null_variance(self):
-    rca = RCA_Supervised(dim=2, num_chunks=30, chunk_size=2)
+    rca = RCA_Supervised(dim=2, pca_comps=3, num_chunks=30, chunk_size=2)
     X = np.hstack((self.iris_points,
         np.eye(self.iris_points.shape[0], M = 1)))
     rca.fit(X, self.iris_labels)

--- a/test/metric_learn_test.py
+++ b/test/metric_learn_test.py
@@ -128,7 +128,7 @@ class TestRCA(MetricTestCase):
         np.eye(self.iris_points.shape[0], M = 1)))
     rca.fit(X, self.iris_labels)
     csep = class_separation(rca.transform(), self.iris_labels)
-    self.assertLess(csep, 0.25)
+    self.assertLess(csep, 0.30)
   def test_digits(self):
     rca = RCA_Supervised(dim=3, num_chunks=100, chunk_size=10)
     rca.fit(self.digits_points, self.digits_labels)

--- a/test/test_base_metric.py
+++ b/test/test_base_metric.py
@@ -39,9 +39,9 @@ SDML_Supervised(balance_param=0.5, num_constraints=None, num_labeled=inf,
                 sparsity_param=0.01, use_cov=True, verbose=False)
 """.strip('\n'))
 
-    self.assertEqual(str(metric_learn.RCA()), "RCA(dim=None)")
+    self.assertEqual(str(metric_learn.RCA()), "RCA(dim=None, pca_comps=None)")
     self.assertEqual(str(metric_learn.RCA_Supervised()),
-                     "RCA_Supervised(chunk_size=2, dim=None, num_chunks=100)")
+                     "RCA_Supervised(chunk_size=2, dim=None, num_chunks=100, pca_comps=None)")
 
     self.assertEqual(str(metric_learn.MLKR()), """
 MLKR(A0=None, alpha=0.0001, epsilon=0.01, max_iter=1000, num_dims=None)


### PR DESCRIPTION
It solves the issue #49 .

The input data is projected with a PCA if the inner covariance matrix is not full rank as advised in the paper "Learning a Mahalanobis Metric from Equivalence Constraints" (JMLR 2005).

I have added two tests that do not work with the current implementation :
  - A feature with a null variance
  - Digits dataset

I have also tested on my own datasets, and this implementation seems robust.