### PR TITLE
Preventing a crash for LSML in a verbose mode

### DIFF
--- a/metric_learn/lsml.py
+++ b/metric_learn/lsml.py
@@ -69,7 +69,7 @@ class LSML(BaseMetricLearner):
     """
     self._prepare_inputs(X, constraints, weights)
     prior_inv = scipy.linalg.inv(self.M_)
-    s_best = self._total_loss(self.M_, prior_inv)
+    l_best = s_best = self._total_loss(self.M_, prior_inv)
     step_sizes = np.logspace(-10, 0, 10)
     if self.verbose:
       print('initial loss', s_best)


### PR DESCRIPTION
If LSML is created with ``verbose=True``, the code crashes here https://github.com/searchivarius/metric-learn/blob/fac5ed5d4f0ae24d274e0956f4b7d2d6d09d2841/metric_learn/lsml.py#L95 due to uninitialized variable ``s_best``. This is I believe a way to fix the problem.