### PR TITLE
Accelerate ITML on high-dimensional data

### DIFF
--- a/metric_learn/itml.py
+++ b/metric_learn/itml.py
@@ -95,30 +95,30 @@ class ITML(BaseMetricLearner):
     gamma_proj = 1. if gamma is np.inf else gamma/(gamma+1.)
     pos_bhat = np.zeros(num_pos) + self.bounds_[0]
     neg_bhat = np.zeros(num_neg) + self.bounds_[1]
+    pos_vv = self.X_[a] - self.X_[b]
+    neg_vv = self.X_[c] - self.X_[d]
     A = self.A_
 
     for it in xrange(self.max_iter):
       # update positives
-      vv = self.X_[a] - self.X_[b]
-      for i,v in enumerate(vv):
+      for i,v in enumerate(pos_vv):
         wtw = v.dot(A).dot(v)  # scalar
         alpha = min(_lambda[i], gamma_proj*(1./wtw - 1./pos_bhat[i]))
         _lambda[i] -= alpha
         beta = alpha/(1 - alpha*wtw)
         pos_bhat[i] = 1./((1 / pos_bhat[i]) + (alpha / gamma))
         Av = A.dot(v)
-        A += beta * np.outer(Av, Av)
+        A += np.outer(Av, Av * beta)
 
       # update negatives
-      vv = self.X_[c] - self.X_[d]
-      for i,v in enumerate(vv):
+      for i,v in enumerate(neg_vv):
         wtw = v.dot(A).dot(v)  # scalar
         alpha = min(_lambda[i+num_pos], gamma_proj*(1./neg_bhat[i] - 1./wtw))
         _lambda[i+num_pos] -= alpha
         beta = -alpha/(1 + alpha*wtw)
         neg_bhat[i] = 1./((1 / neg_bhat[i]) - (alpha / gamma))
         Av = A.dot(v)
-        A += beta * np.outer(Av, Av)
+        A += np.outer(Av, Av * beta)
 
       normsum = np.linalg.norm(_lambda) + np.linalg.norm(lambdaold)
       if normsum == 0:


### PR DESCRIPTION
Admittedly, the changes proposed in this PR are very small, but in my test-case with 1024-dimensional data and 90 constraints, the run-time of ITML was reduced from 27 to 12 seconds.

Besides the changes in this PR, ITML could be accelerated further by not learning the metric `A` directly, but the decomposition `L` with `A = L^T * L` instead, as suggested in the ITML paper. However, that would require an efficient function for rank-1 updates/downdates of a Cholesky decomposition which is currently not available in `scipy` or `numpy`. And I don't think you would like to make another third-party module such as [`choldate`](https://github.com/jcrudy/choldate) a dependency just because of this.